### PR TITLE
fix: update similar_asserts and implement Eq

### DIFF
--- a/lang-lexer/src/context.rs
+++ b/lang-lexer/src/context.rs
@@ -7,7 +7,7 @@ use lang_util::{FileId, SmolStr};
 use glsl_lang_types::ast;
 
 /// Parsing options
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ParseOptions {
     /// Default GLSL version number to parse source as
     pub default_version: u16,

--- a/lang-lexer/src/v1.rs
+++ b/lang-lexer/src/v1.rs
@@ -370,7 +370,7 @@ impl<'i> LangLexerIterator for LexerIterator<'i> {
 }
 
 /// Lexical analysis error
-#[derive(Debug, PartialEq, Error)]
+#[derive(Debug, PartialEq, Eq, Error)]
 pub enum LexicalError {
     /// Invalid int literal
     #[error("invalid int literal: {source}")]

--- a/lang-lexer/src/v1/preprocessor_token.rs
+++ b/lang-lexer/src/v1/preprocessor_token.rs
@@ -5,7 +5,7 @@ use super::{
     ParseContext, ParseOptions, Token,
 };
 
-#[derive(Debug, Clone, PartialEq, Logos)]
+#[derive(Debug, Clone, PartialEq, Eq, Logos)]
 #[logos(extras = (ParseContext, ParseOptions))]
 pub enum PreprocessorToken<'i> {
     #[regex("[a-zA-Z_][a-zA-Z_0-9]*")]

--- a/lang-lexer/src/v2_min.rs
+++ b/lang-lexer/src/v2_min.rs
@@ -10,7 +10,7 @@ use lang_util::{
 pub mod str;
 
 /// Lexical analysis error
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LexicalError {
     /// Invalid token in lexical analysis
     Token {

--- a/lang-pp/src/processor/expr.rs
+++ b/lang-pp/src/processor/expr.rs
@@ -119,11 +119,11 @@ impl<'i, I: Iterator<Item = &'i OutputToken>> ExprEvaluator<'i, I> {
                     IDENT_KW => {
                         // Free-standing form, get the ident name
                         let ident = Unescaped::new(self.bump()?.text()).to_string();
-                        return Some(Ok(if self.state.get_definition(&ident).is_some() {
+                        Some(Ok(if self.state.get_definition(&ident).is_some() {
                             1
                         } else {
                             0
-                        }));
+                        }))
                     }
                     LPAREN => {
                         // Parenthesis form

--- a/lang-pp/tests/common/mod.rs
+++ b/lang-pp/tests/common/mod.rs
@@ -105,7 +105,7 @@ pub fn test_file(path: impl AsRef<Path>) {
         }
 
         if let Some(idx) = formatted.find(": ") {
-            formatted = formatted[..idx].replace("\\", "/") + &formatted[idx..];
+            formatted = formatted[..idx].replace('\\', "/") + &formatted[idx..];
         }
 
         writeln!(errorsf, "{}", formatted).unwrap();

--- a/lang-types/src/ast.rs
+++ b/lang-types/src/ast.rs
@@ -30,7 +30,7 @@ pub use lang_util::{
 };
 
 /// A generic identifier.
-#[derive(Clone, Debug, PartialEq, PartialOrd, Hash, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Hash, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 #[lang_util(display(leaf))]
@@ -73,7 +73,7 @@ impl fmt::Display for IdentifierData {
 }
 
 /// Any type name.
-#[derive(Clone, Debug, PartialEq, PartialOrd, Hash, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Hash, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 #[lang_util(display(leaf))]
@@ -105,7 +105,7 @@ impl fmt::Display for TypeNameData {
 }
 
 /// A path literal.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub enum PathData {
@@ -787,7 +787,7 @@ pub enum LayoutQualifierSpecData {
 }
 
 /// Precision qualifier.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub enum PrecisionQualifierData {
@@ -803,7 +803,7 @@ pub enum PrecisionQualifierData {
 }
 
 /// Interpolation qualifier.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub enum InterpolationQualifierData {
@@ -1139,7 +1139,7 @@ impl From<f64> for ExprData {
 }
 
 /// All unary operators that exist in GLSL.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub enum UnaryOpData {
@@ -1164,7 +1164,7 @@ pub enum UnaryOpData {
 }
 
 /// All binary operators that exist in GLSL.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub enum BinaryOpData {
@@ -1228,7 +1228,7 @@ pub enum BinaryOpData {
 }
 
 /// All possible operators for assigning expressions.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub enum AssignmentOpData {
@@ -1495,7 +1495,7 @@ pub enum JumpStatementData {
 /// As it’s important to carry them around the AST because they cannot be substituted in a normal
 /// preprocessor (they’re used by GPU’s compilers), those preprocessor directives are available for
 /// inspection.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub enum PreprocessorData {
@@ -1546,7 +1546,7 @@ pub enum PreprocessorData {
 /// A #define preprocessor directive.
 ///
 /// Allows any expression but only Integer and Float literals make sense
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub enum PreprocessorDefineData {
@@ -1570,7 +1570,7 @@ pub enum PreprocessorDefineData {
 }
 
 /// An #else preprocessor directive.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub struct PreprocessorElseIfData {
@@ -1580,7 +1580,7 @@ pub struct PreprocessorElseIfData {
 }
 
 /// An #error preprocessor directive.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub struct PreprocessorErrorData {
@@ -1590,7 +1590,7 @@ pub struct PreprocessorErrorData {
 }
 
 /// An #if preprocessor directive.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub struct PreprocessorIfData {
@@ -1600,7 +1600,7 @@ pub struct PreprocessorIfData {
 }
 
 /// An #ifdef preprocessor directive.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub struct PreprocessorIfDefData {
@@ -1610,7 +1610,7 @@ pub struct PreprocessorIfDefData {
 }
 
 /// A #ifndef preprocessor directive.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub struct PreprocessorIfNDefData {
@@ -1620,7 +1620,7 @@ pub struct PreprocessorIfNDefData {
 }
 
 /// An #include name annotation.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub struct PreprocessorIncludeData {
@@ -1629,7 +1629,7 @@ pub struct PreprocessorIncludeData {
 }
 
 /// A #line preprocessor directive.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub struct PreprocessorLineData {
@@ -1642,7 +1642,7 @@ pub struct PreprocessorLineData {
 
 /// A #pragma preprocessor directive.
 /// Holds compiler-specific command.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub struct PreprocessorPragmaData {
@@ -1652,7 +1652,7 @@ pub struct PreprocessorPragmaData {
 }
 
 /// A #undef preprocessor directive.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub struct PreprocessorUndefData {
@@ -1662,7 +1662,7 @@ pub struct PreprocessorUndefData {
 }
 
 /// A #version preprocessor directive.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub struct PreprocessorVersionData {
@@ -1674,7 +1674,7 @@ pub struct PreprocessorVersionData {
 }
 
 /// A #version profile annotation.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub enum PreprocessorVersionProfileData {
@@ -1690,7 +1690,7 @@ pub enum PreprocessorVersionProfileData {
 }
 
 /// An #extension preprocessor directive.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub struct PreprocessorExtensionData {
@@ -1701,7 +1701,7 @@ pub struct PreprocessorExtensionData {
 }
 
 /// An #extension name annotation.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub enum PreprocessorExtensionNameData {
@@ -1713,7 +1713,7 @@ pub enum PreprocessorExtensionNameData {
 }
 
 /// An #extension behavior annotation.
-#[derive(Clone, Debug, PartialEq, NodeContent)]
+#[derive(Clone, Debug, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub enum PreprocessorExtensionBehaviorData {
@@ -1732,7 +1732,7 @@ pub enum PreprocessorExtensionBehaviorData {
 }
 
 /// A comment
-#[derive(Debug, Clone, PartialEq, NodeContent)]
+#[derive(Debug, Clone, PartialEq, Eq, NodeContent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub enum CommentData {

--- a/lang-util-dev/Cargo.toml
+++ b/lang-util-dev/Cargo.toml
@@ -14,4 +14,4 @@ categories = ["parsing"]
 
 [dependencies]
 derive_more = "0.99"
-similar-asserts = "1.2"
+similar-asserts = "1.4"

--- a/lang-util-dev/src/test_util.rs
+++ b/lang-util-dev/src/test_util.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::{fs, path::PathBuf};
 
-use similar_asserts::assert_str_eq;
+use similar_asserts::assert_eq;
 
 /// Key for differentiating between kinds of test outputs
 pub trait PathKey: std::fmt::Display + PartialEq + Eq + std::hash::Hash + Clone + Sized {
@@ -117,7 +117,7 @@ impl<K: PathKey + 'static> Paths<K> {
                         let public = std::fs::read_to_string(&public_result)
                             .expect("failed to read snapshot");
 
-                        assert_str_eq!(local, public, "snapshot mismatch");
+                        assert_eq!(local, public, "snapshot mismatch");
                     }
                     Mode::Bump => {
                         std::fs::copy(local_result, public_result)

--- a/lang-util/src/error.rs
+++ b/lang-util/src/error.rs
@@ -10,7 +10,7 @@ use text_size::{TextRange, TextSize};
 use crate::{located::Located, position::LexerPosition, token::Token, FileId};
 
 /// Information about a lexed token
-#[derive(Debug, Clone, PartialEq, PartialOrd, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
 #[cfg_attr(feature = "serde", derive(rserde::Serialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub struct TokenDescription {
@@ -97,7 +97,7 @@ pub fn error_location<T, E: LexicalError>(
 
 // We represent tokens as formatted string since we only want to display them
 /// Parsing error kind
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParseErrorKind<E: LexicalError> {
     /// An invalid token was encountered during lexical analysis
     InvalidToken,

--- a/lang-util/src/token.rs
+++ b/lang-util/src/token.rs
@@ -1,7 +1,7 @@
 //! Token derive support definitions
 
 /// Information about a known token
-#[derive(Debug, Clone, PartialEq, PartialOrd, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
 #[cfg_attr(feature = "serde", derive(rserde::Serialize))]
 #[cfg_attr(feature = "serde", serde(crate = "rserde"))]
 pub struct TokenDescriptor {

--- a/lang/src/transpiler/glsl.rs
+++ b/lang/src/transpiler/glsl.rs
@@ -36,7 +36,7 @@ use std::fmt::Write;
 use lazy_static::lazy_static;
 
 /// Indentation style of the output
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IndentStyle {
     /// No indentation is generated
     None,
@@ -86,7 +86,7 @@ impl Default for IndentStyle {
 }
 
 /// Formatter whitespace
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Whitespace {
     /// No whitespace
     None,
@@ -111,7 +111,7 @@ impl Whitespace {
 }
 
 /// Formatting settings for the GLSL transpiler
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FormattingSettings {
     /// Indentation style of the output
     pub indent_style: IndentStyle,
@@ -153,7 +153,7 @@ impl Default for FormattingSettings {
 }
 
 /// Formatting state of the GLSL transpiler
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FormattingState<'s> {
     /// Formatting settings
     pub settings: &'s FormattingSettings,
@@ -1237,7 +1237,7 @@ where
 {
     match **i {
         ast::FunIdentifierData::TypeSpecifier(ref n) => show_type_specifier(f, n, state),
-        ast::FunIdentifierData::Expr(ref e) => show_expr(f, &*e, state),
+        ast::FunIdentifierData::Expr(ref e) => show_expr(f, e, state),
     }
 }
 


### PR DESCRIPTION
Fixes clippy deprecated warnings about assert_str_eq in the similar_asserts crate.