### PR TITLE
ci: retry cargo publish

### DIFF
--- a/ci/release.sh
+++ b/ci/release.sh
@@ -17,11 +17,25 @@ for P in lang-util-dev \
          lang-quote \
          lang-cli ; do
   (
+    set +e
     echo "Publishing $P" >&2
     cd $P
-    cargo publish "$@"
 
-    echo "Waiting for index update" >&2
-    sleep 10s
+    SUCCESS=0
+    for TRIES in $(seq 0 30); do
+      OUTPUT=$(cargo publish 2>&1)
+      if [[ $? == 0 ]] || [[ $OUTPUT =~ "already uploaded" ]]; then
+        SUCCESS=1
+        break
+      else
+        echo $OUTPUT
+        echo "Waiting for index update" >&2
+        sleep 10s
+      fi
+    done
+
+    if [[ $SUCCESS != 1 ]]; then
+      exit 1
+    fi
   )
 done


### PR DESCRIPTION
Index updates may take longer than expected, and we need those to
publish packages in topological order. We try for up to 5min/package.