### PR TITLE
Fix v2-full lexer injecting pp. directives after ext. declarations

### DIFF
--- a/lang-lexer/src/v2_full/directives.rs
+++ b/lang-lexer/src/v2_full/directives.rs
@@ -3,7 +3,7 @@ use glsl_lang_types::ast::{
     self, PreprocessorExtensionBehaviorData, PreprocessorExtensionNameData,
     PreprocessorVersionProfileData,
 };
-use lang_util::{position::LexerPosition, NodeContent, TextSize};
+use lang_util::NodeContent;
 
 #[derive(Default, Debug, Clone)]
 pub struct Directives {
@@ -111,17 +111,17 @@ impl Directives {
             let current_declaration = &root.0[declaration_idx];
 
             // Find where the range starts
-            let actual_start = if let Some(start) = start {
-                // This is the end of the previous declaration
-                start
-            } else if let Some(current_start) = current_declaration.span.map(|span| span.start()) {
-                // Start from the beginning of the file
-                LexerPosition::new(current_start.source_id, TextSize::default())
-            } else {
-                // No span information, keep looking
-                declaration_idx += 1;
-                continue;
-            };
+            let actual_start =
+                if let Some(current_start) = current_declaration.span.map(|span| span.start()) {
+                    current_start
+                } else if let Some(start) = start {
+                    // This is the end of the previous declaration
+                    start
+                } else {
+                    // No span information, keep looking
+                    declaration_idx += 1;
+                    continue;
+                };
 
             // Find where the current declaration ends
             let end = if let Some(current_end) = current_declaration.span.map(|span| span.end()) {

--- a/lang/src/parse_tests.rs
+++ b/lang/src/parse_tests.rs
@@ -2612,8 +2612,11 @@ fn parse_vulkan_types() {
 #[cfg(not(feature = "lexer-v2-full"))]
 fn parse_pp(
     source: &str,
-) -> Result<ast::Preprocessor, parse::ParseError<<parse::DefaultLexer as HasLexerError>::Error>> {
-    ast::Preprocessor::parse(source)
+) -> Result<
+    impl Iterator<Item = ast::ExternalDeclaration>,
+    parse::ParseError<<parse::DefaultLexer as HasLexerError>::Error>,
+> {
+    Ok(ast::TranslationUnit::parse(source)?.0.into_iter())
 }
 
 #[cfg(feature = "lexer-v2-full")]


### PR DESCRIPTION
When using the v2-full lexer it is necessary to inject at least some preprocessor directives back to the AST so they appear in the transpiled GLSL.

The lexer supports this use case for preprocessor directives in external declaration position, but the tests that cover this injection functionality do not check that the results are correct when there are several external declarations in a translation unit.

As a result, when transpiling the following GLSL source back to GLSL:

```glsl
#version 110
invariant x;
#pragma once
invariant y;
```

The output is unexpected:

```glsl
invariant x;
#version 110
invariant y;
#pragma once
```

Given that the order of preprocessor directives is significant, this is an incorrect behavior. I pinned down the cause of this problem to a bad computation of the declaration start position in the injection code.

These changes improve the AST directive injection in this case and add a test for this problem.

(By the way, thank you for these wonderful GLSL parsing libraries, they are very much needed! :heart:)