### PR TITLE
Replace dependency on `lazy_static` by `once_cell`

### DIFF
--- a/lang-pp/Cargo.toml
+++ b/lang-pp/Cargo.toml
@@ -30,7 +30,7 @@ bimap = { version = "0.6", optional = true }
 itertools = { version = "0.10", optional = true }
 
 # Extension registry
-lazy_static = { version = "1.4", optional = true }
+once_cell = { version = "1.17.1", optional = true }
 
 [dev-dependencies]
 lang-util-dev = "0.4.0"
@@ -44,5 +44,5 @@ string_cache_codegen = "0.5"
 
 [features]
 default = []
-exts = ["lazy_static"]
+exts = ["once_cell"]
 full = ["exts", "rowan", "cbitset", "static_assertions", "bimap", "itertools"]

--- a/lang-pp/src/exts.rs
+++ b/lang-pp/src/exts.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use once_cell::sync::Lazy;
+
 use crate::types::type_names::TypeNameAtom;
 
 #[macro_use]
@@ -574,7 +576,5 @@ impl Default for Registry {
     }
 }
 
-lazy_static::lazy_static! {
-    pub static ref DEFAULT_REGISTRY: Registry = Registry::default();
-    pub static ref EMPTY_REGISTRY: Registry = Registry::new();
-}
+pub static DEFAULT_REGISTRY: Lazy<Registry> = Lazy::new(Registry::default);
+pub static EMPTY_REGISTRY: Lazy<Registry> = Lazy::new(Registry::new);

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["parser-implementations", "rendering"]
 
 [dependencies]
 lalrpop-util = { version = "0.19.8", default-features = false, features = ["std"] }
-lazy_static = "1.4"
+once_cell = "1.17.1"
 thiserror = "1.0"
 
 lang-util = { version = "0.4.0", features = ["lalrpop"] }

--- a/lang/src/transpiler/glsl.rs
+++ b/lang/src/transpiler/glsl.rs
@@ -33,7 +33,7 @@
 
 use std::fmt::Write;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
 /// Indentation style of the output
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -328,9 +328,7 @@ impl<'s> From<&'s FormattingSettings> for FormattingState<'s> {
     }
 }
 
-lazy_static! {
-    static ref DEFAULT_SETTINGS: FormattingSettings = FormattingSettings::default();
-}
+static DEFAULT_SETTINGS: Lazy<FormattingSettings> = Lazy::new(FormattingSettings::default);
 
 impl Default for FormattingState<'static> {
     fn default() -> Self {


### PR DESCRIPTION
`once_cell` is a more ergonomic alternative to `lazy_static` which provides a more straightforward syntax for lazily initialized statics. Its API is also closer to the nightly `std::sync::LazyLock`, which should make it easier to migrate to it in the event that it gets stabilized. `once_cell` is also pulled in transitively more often than `lazy_static` by the dependencies of this project, and I think it's likely that the ecosystem will move to `once_cell`.