### PR TITLE
fix(transpiler): correct transpilation of precision qualifiers

### DIFF
--- a/lang/src/transpiler/glsl.rs
+++ b/lang/src/transpiler/glsl.rs
@@ -900,7 +900,7 @@ where
     match **p {
         ast::PrecisionQualifierData::High => f.write_str("highp"),
         ast::PrecisionQualifierData::Medium => f.write_str("mediump"),
-        ast::PrecisionQualifierData::Low => f.write_str("low"),
+        ast::PrecisionQualifierData::Low => f.write_str("lowp"),
     }
 }
 
@@ -1259,6 +1259,7 @@ where
         }
         ast::DeclarationData::Precision(ref qual, ref ty) => {
             show_precision_qualifier(f, qual, state)?;
+            f.write_str(" ")?;
             show_type_specifier(f, ty, state)?;
             state.write_declaration_terminator(f)
         }


### PR DESCRIPTION
These changes were submitted by @bendmorris on https://github.com/phaazon/glsl/pull/152 for inclusion on the GLSL crate, but they never made it upstream, and it seems likely that they won't make it anytime soon. This repository seems better maintained, so it probably is a good home for those fixes :smile: 