### PR TITLE
fix(lang-lexer/inject): better support injection of pp. dirs. from multiple files

### DIFF
--- a/lang-cli/Cargo.toml
+++ b/lang-cli/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-interface", "parser-implementations", "rendering"]
 
 [dependencies]
 glsl-lang = { version = "=0.5.1", features = ["lexer-v2-full"] }
+glsl-lang-pp = { version = "=0.5.1" }
 lang-util = "=0.5.1"
 argh = "0.1"
 

--- a/lang-lexer/src/v2_full/directives.rs
+++ b/lang-lexer/src/v2_full/directives.rs
@@ -1,4 +1,9 @@
-use glsl_lang_pp::processor::event::{DirectiveKind, EventDirective};
+use std::cmp;
+
+use glsl_lang_pp::processor::{
+    event::{DirectiveKind, EventDirective},
+    nodes::VersionProfile,
+};
 use glsl_lang_types::ast::{
     self, PreprocessorExtensionBehaviorData, PreprocessorExtensionNameData,
     PreprocessorVersionProfileData,
@@ -15,36 +20,62 @@ impl Directives {
         &self.directives
     }
 
-    fn get_declaration(directive: &EventDirective) -> Option<ast::ExternalDeclaration> {
+    fn get_declaration(
+        directive: &EventDirective,
+        highest_version: &mut Option<(u16, Option<VersionProfile>)>,
+    ) -> Option<ast::ExternalDeclaration> {
         let start = directive.text_range().start();
         let end = directive.text_range().end();
 
         match directive.kind() {
-            DirectiveKind::Version(version) => Some(
-                ast::ExternalDeclarationData::Preprocessor(
-                    ast::PreprocessorData::Version(
-                        ast::PreprocessorVersionData {
-                            version: version.number,
-                            profile: match version.parsed_profile {
-                                None => None,
-                                Some(glsl_lang_pp::processor::nodes::VersionProfile::None) => None,
-                                Some(glsl_lang_pp::processor::nodes::VersionProfile::Core) => {
-                                    Some(PreprocessorVersionProfileData::Core.into())
-                                }
-                                Some(
-                                    glsl_lang_pp::processor::nodes::VersionProfile::Compatibility,
-                                ) => Some(PreprocessorVersionProfileData::Compatibility.into()),
-                                Some(glsl_lang_pp::processor::nodes::VersionProfile::Es) => {
-                                    Some(PreprocessorVersionProfileData::Es.into())
-                                }
-                            },
-                        }
-                        .into(),
+            DirectiveKind::Version(version) => {
+                let version_number = version.number;
+                let profile = version.parsed_profile;
+
+                let had_highest_version;
+                let (highest_version_number, highest_profile) = match highest_version {
+                    Some(version_data) => {
+                        had_highest_version = true;
+                        version_data
+                    }
+                    None => {
+                        had_highest_version = false;
+                        highest_version.insert((version_number, profile))
+                    }
+                };
+
+                *highest_version_number = cmp::max(version_number, *highest_version_number);
+                *highest_profile = cmp::max(
+                    // Wrap in Some to avoid OpenGL ES being considered higher than no profile (i.e., core profile)
+                    Some(profile.unwrap_or(VersionProfile::None)),
+                    *highest_profile,
+                );
+
+                (!had_highest_version).then_some(
+                    ast::ExternalDeclarationData::Preprocessor(
+                        ast::PreprocessorData::Version(
+                            ast::PreprocessorVersionData {
+                                version: version_number,
+                                profile: match profile {
+                                    None | Some(VersionProfile::None) => None,
+                                    Some(VersionProfile::Core) => {
+                                        Some(PreprocessorVersionProfileData::Core.into())
+                                    }
+                                    Some(VersionProfile::Compatibility) => {
+                                        Some(PreprocessorVersionProfileData::Compatibility.into())
+                                    }
+                                    Some(VersionProfile::Es) => {
+                                        Some(PreprocessorVersionProfileData::Es.into())
+                                    }
+                                },
+                            }
+                            .into(),
+                        )
+                        .spanned(start, end),
                     )
                     .spanned(start, end),
                 )
-                .spanned(start, end),
-            ),
+            }
 
             DirectiveKind::Pragma(pragma) => Some(
                 ast::ExternalDeclarationData::Preprocessor(
@@ -96,6 +127,7 @@ impl Directives {
                 )
                 .spanned(start, end),
             ),
+
             _ => None,
         }
     }
@@ -103,6 +135,8 @@ impl Directives {
     pub fn inject(mut self, root: &mut ast::TranslationUnit) -> Directives {
         let mut directive_idx = 0;
         let mut declaration_idx = 0;
+        let mut highest_version = None;
+        let mut version_directive_declaration_idx = None;
 
         // Insert directives
         let mut start = None;
@@ -137,23 +171,28 @@ impl Directives {
                 let current_directive = &self.directives[directive_idx];
                 let span = current_directive.text_range();
 
-                // TODO: What happends to directives from multiple files?
-                if span.source_id() == actual_start.source_id {
-                    if span.end().offset <= actual_start.offset {
-                        if let Some(declaration) = Self::get_declaration(current_directive) {
-                            // Add to ast
-                            root.0.insert(declaration_idx, declaration);
-                            declaration_idx += 1;
-                            // Processed, remove from directive list
-                            self.directives.remove(directive_idx);
-                        } else {
-                            // Can't be processed, skip it
-                            directive_idx += 1;
+                if span.end().offset <= actual_start.offset {
+                    if let Some(declaration) =
+                        Self::get_declaration(current_directive, &mut highest_version)
+                    {
+                        // Add to ast
+                        root.0.insert(declaration_idx, declaration);
+
+                        if matches!(current_directive.kind(), DirectiveKind::Version(_)) {
+                            version_directive_declaration_idx.get_or_insert(declaration_idx);
                         }
+
+                        declaration_idx += 1;
+
+                        // Processed, remove from directive list
+                        self.directives.remove(directive_idx);
                     } else {
-                        // This directive comes later
-                        break;
+                        // Can't/shouldn't be processed, skip it
+                        directive_idx += 1;
                     }
+                } else {
+                    // This directive comes later
+                    break;
                 }
             }
 
@@ -164,13 +203,50 @@ impl Directives {
             start = Some(end);
         }
 
-        // TODO: Check source_id?
+        // Append any remaining directives
         while directive_idx < self.directives.len() {
-            if let Some(declaration) = Self::get_declaration(&self.directives[directive_idx]) {
+            let current_directive = &self.directives[directive_idx];
+
+            if let Some(declaration) =
+                Self::get_declaration(current_directive, &mut highest_version)
+            {
                 root.0.push(declaration);
+
+                if matches!(current_directive.kind(), DirectiveKind::Version(_)) {
+                    version_directive_declaration_idx.get_or_insert(root.0.len() - 1);
+                }
+
                 self.directives.remove(directive_idx);
             } else {
                 directive_idx += 1;
+            }
+        }
+
+        // Set the version directive value to the highest (i.e., the one that requires the most
+        // OpenGL features) that was found
+        if let (
+            Some(version_directive_declaration_idx),
+            Some((highest_version_number, highest_profile)),
+        ) = (version_directive_declaration_idx, highest_version)
+        {
+            if let ast::ExternalDeclarationData::Preprocessor(preprocessor_data) =
+                &mut root.0[version_directive_declaration_idx].content
+            {
+                if let ast::PreprocessorData::Version(preprocessor_version) =
+                    &mut preprocessor_data.content
+                {
+                    preprocessor_version.version = highest_version_number;
+                    preprocessor_version.profile = match highest_profile {
+                        None | Some(VersionProfile::None) => None,
+                        Some(VersionProfile::Core) => {
+                            Some(PreprocessorVersionProfileData::Core.into())
+                        }
+                        Some(VersionProfile::Compatibility) => {
+                            Some(PreprocessorVersionProfileData::Compatibility.into())
+                        }
+                        Some(VersionProfile::Es) => Some(PreprocessorVersionProfileData::Es.into()),
+                    };
+                }
             }
         }
 

--- a/lang-lexer/src/v2_full/directives.rs
+++ b/lang-lexer/src/v2_full/directives.rs
@@ -171,7 +171,11 @@ impl Directives {
                 let current_directive = &self.directives[directive_idx];
                 let span = current_directive.text_range();
 
-                if span.end().offset <= actual_start.offset {
+                // For directives in #include'd files, a previous #include directive event prevents
+                // inserting them too soon in the top-level file
+                if span.end().offset <= actual_start.offset
+                    || actual_start.source_id != span.source_id()
+                {
                     if let Some(declaration) =
                         Self::get_declaration(current_directive, &mut highest_version)
                     {

--- a/lang-pp/src/processor/nodes.rs
+++ b/lang-pp/src/processor/nodes.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, convert::TryFrom, str::FromStr};
+use std::{borrow::Cow, cmp::Ordering, convert::TryFrom, str::FromStr};
 
 use arrayvec::ArrayVec;
 use rowan::NodeOrToken;
@@ -271,6 +271,36 @@ impl FromStr for VersionProfile {
                 return Err(());
             }
         })
+    }
+}
+
+impl VersionProfile {
+    /// Returns an integer representing the relative size of the feature set of an OpenGL profile.
+    /// Profiles with a higher index are assumed to offer a superset of the features of profiles
+    /// with a lower index.
+    fn as_feature_set_size_index(&self) -> usize {
+        // OpenGL ES offers a feature set smaller than the core profile.
+        // Conversely, the core profile has less features than the compatibility profile.
+        // When no profile is specified, the profile defaults to core
+        match self {
+            Self::None | Self::Core => 1,
+            Self::Compatibility => 2,
+            Self::Es => 0,
+        }
+    }
+}
+
+impl PartialOrd for VersionProfile {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.as_feature_set_size_index()
+            .partial_cmp(&other.as_feature_set_size_index())
+    }
+}
+
+impl Ord for VersionProfile {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_feature_set_size_index()
+            .cmp(&other.as_feature_set_size_index())
     }
 }
 

--- a/lang/data/tests/multifile_pp_a.glsl
+++ b/lang/data/tests/multifile_pp_a.glsl
@@ -1,0 +1,6 @@
+#version 400 core
+#extension GL_GOOGLE_include_directive : require
+
+#include "multifile_pp_b.glsl"
+
+uniform vec2 y;

--- a/lang/data/tests/multifile_pp_b.glsl
+++ b/lang/data/tests/multifile_pp_b.glsl
@@ -1,0 +1,2 @@
+#version 460 core
+uniform vec3 x;


### PR DESCRIPTION
As of now, injecting preprocessor directives found in included files back into the AST when using the `v2-full` lexer is not supported. Attempting to do so will trap the `Directives::inject` method in the following loop forever, as a different source file ID will cause neither `directive_idx` to be incremented or `break` to be reached:

https://github.com/vtavernier/glsl-lang/blob/881c0e472bfa990150c7a3fcd8b3efc787b66ccc/lang-lexer/src/v2_full/directives.rs#L134-L158

After giving the situation some thought, I think it's more appropriate to inject the preprocessor directives that we are currently capable of injecting, regardless of whether they come from a different file:

- `#pragma`: most of these directives are to be defined by the GLSL compiler implementation, and those documented in the GLSL specification change the compiler state in a way where only their location in the source is relevant, not the file they were expanded from.
- `#extension`: similar to `#pragma`. Furthermore, the specification explicitly states that "directives that occur later override those seen earlier".
- `#version`: the GLSL specification states that "the #version directive must occur in a shader before anything else". This suggests (but does not unequivocally assert) that there should only be one `#version` directive per shader.

By now, I think it is clear that `#pragma` and `#extension` can be injected as they are without further ado. However, handling `#version` in combination with `#include` requires further work, in my view.

Let's consider a shader A that is valid on its own, but does not contain a `void main()` function (this is allowed by the GLSL specification, as long as the shader is linked together with another shader that defines this function). Now, consider a shader B that `#include`s shader A and defines `void main()`. Let's assume that the GLSL application compiles shader B. In this scenario, I'd argue that it makes sense for both A and B to have a `#version` directive in the beginning of their respective sources, because both are shaders, according to the specification. A could define a `void main()` function only if a preprocessor directive set by B before the `#include` is unset, allowing it to be linked as a completely standalone shader, where the `#version` directive can't be placed anywhere else. Remarkably, [the specifications for `#include` extensions like `ARB_shading_language_include`](https://registry.khronos.org/OpenGL/extensions/ARB/ARB_shading_language_include.txt) do not mention how to handle multiple `#version` directives at all.

Given the above scenario, I think that a good solution is to make sure that `Directives::inject` only emits at most one `#version` directive, with its version and profile set to the highest version and most featureful profile among those specified in all `#version` directives. As far as I know, GLSL versions are backwards compatible, and even if they weren't, several `#version` directives are likely to violate the GLSL specification, so there would be no way to reconcile GLSL sources targeting incompatible GLSL versions anyway.

These changes let `#pragma` and `#extension` directives coming from included files be injected anyway. `#version` directives are injected too, but only one `#version` directive is ever injected, according to the technique stated in the previous paragraph.

(By the way, I appreciate your prompt PR reviews. As you can see, I'm taking these crates for a good spin, trying to improve what I find in the process. I think that Rust deserves a rock-solid GLSL parser library :heart:)