### PR TITLE
fix(transpiler): add missing brackets for array expressions

### DIFF
--- a/lang/src/transpiler/glsl.rs
+++ b/lang/src/transpiler/glsl.rs
@@ -1325,7 +1325,9 @@ where
                 f.write_char(')')?;
             }
 
-            show_expr(f, a, state)
+            f.write_char('[')?;
+            show_expr(f, a, state)?;
+            f.write_char(']')
         }
         ast::ExprData::FunCall(ref fun, ref args) => {
             show_function_identifier(f, fun, state)?;
@@ -2441,6 +2443,11 @@ mod tests {
     fn dot_parentheses() {
         check_expr("a.x", expect![["a.x"]]);
         check_expr("(a + b).x", expect![[r#"(a + b).x"#]]);
+    }
+
+    #[test]
+    fn array_indexes() {
+        check_expr("arr[0][0]", expect![["arr[0][0]"]]);
     }
 
     #[test]


### PR DESCRIPTION
As defined in the GLSL grammar, postfix expressions may be suffixed by an integer expression between brackets to index primary expressions such as matrices and arrays. The AST represents such suffix with a Bracket node.

This node was slightly refactored when ported from the glsl crate to contain an expression instead of an array specifier, which better follows the GLSL grammar, but introduced a regression due to not explicitly writing the necessary brackets. For example, this input:

```glsl
void main() { ProjMat[0][0] = 0.0; }
```

Would transpile to the following incorrect output:

```glsl
void main() { ProjMat00 = 0.0; }
```

To fix this, surround the integer expression between brackets and add the corresponding regression test.